### PR TITLE
Fix: Parsing with unknown handler

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -82,6 +82,7 @@ module.exports = function(args, opts) {
 
 	let idx = 0;
 	const out = { _: [] };
+	const allOpts = opts.boolean.concat(opts.string);
 
 	while (args[idx] !== void 0) {
 		let incr = 1;
@@ -102,8 +103,9 @@ module.exports = function(args, opts) {
 			const flag = segs[0].substr(isGroup ? 1 : 2);
 			len = flag.length;
 			const key = isGroup ? flag[len - 1] : flag;
+			const isMatch = aliases[key] !== void 0 || allOpts.indexOf(flag) !== -1;
 
-			if (opts.unknown !== void 0 && aliases[key] === void 0) {
+			if (opts.unknown !== void 0 && !isMatch) {
 				return opts.unknown(segs[0]);
 			}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,10 @@ function toNum(any) {
 
 function getAlibi(names, arr) {
 	if (arr.length === 0) return arr;
-	let k, i = 0, len = arr.length, vals = [];
+	let k,
+		i = 0,
+		len = arr.length,
+		vals = [];
 	for (; i < len; i++) {
 		k = arr[i];
 		vals.push(k);

--- a/test/unknown.js
+++ b/test/unknown.js
@@ -1,6 +1,45 @@
 const test = require('tape');
 const fn = require('../lib');
 
+test('boolean is not unknown', t => {
+	const unknown = [];
+	const unknownFn = arg => (unknown.push(arg), false);
+	const argv = ['--herp'];
+	const opts = {
+		boolean: 'herp',
+		unknown: unknownFn
+	};
+	const aliasedArgv = fn(argv, opts);
+	t.same(unknown, []);
+	t.end();
+});
+
+test('string is not unknown', t => {
+	const unknown = [];
+	const unknownFn = arg => (unknown.push(arg), false);
+	const argv = ['--herp herp'];
+	const opts = {
+		string: 'herp',
+		unknown: unknownFn
+	};
+	const aliasedArgv = fn(argv, opts);
+	t.same(unknown, []);
+	t.end();
+});
+
+test('default is not unknown', t => {
+	const unknown = [];
+	const unknownFn = arg => (unknown.push(arg), false);
+	const argv = ['--herp'];
+	const opts = {
+		default: { herp: false },
+		unknown: unknownFn
+	};
+	const aliasedArgv = fn(argv, opts);
+	t.same(unknown, []);
+	t.end();
+});
+
 test('boolean and alias is not unknown', t => {
 	const unknown = [];
 	const unknownFn = arg => (unknown.push(arg), false);


### PR DESCRIPTION
Closes #4

This PR allows exact matching on `string` and `boolean` types. Included tests all fail before the change.

This slows things down ever so slightly. It's still faster than everything else by far, but worth noting.

### Before

```js
const opts = { boolean: ['check'], unknown: (arg) => console.log('unknown arg:', arg) }
mri(['--check'], opts) // this hits the unknown handler
```

mri x 239,216 ops/sec ±0.87% (88 runs sampled)

### After

```js
const opts = { boolean: ['check'], unknown: (arg) => console.log('unknown arg:', arg) }
mri(['--check'], opts) // resolves args correctly, check is true
```

mri x 200,861 ops/sec ±0.87% (88 runs sampled)

