### PR TITLE
fix: parse zero-number like value

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,14 @@ const EQQ = /\s|=/;
 const FLAG = /^-{1,2}/;
 const PREFIX = /^--no-/i;
 
+function isNum(any) {
+	const num = +any;
+	if (num * 0 !== 0) return false; // undefined, NaN, Infinity, boolean
+	if (num === any) return true;
+	if (typeof any === 'string' && any.trim() !== '') return true;
+	return false; // null
+}
+
 function isBool(any) {
 	return typeof any === 'boolean';
 }
@@ -21,7 +29,7 @@ function toBool(any) {
 }
 
 function toNum(any) {
-	return (!isBool(any) && Number(any)) || any;
+	return isNum(any) ? Number(any) : any;
 }
 
 function getAlibi(names, arr) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,14 +4,6 @@ const EQQ = /\s|=/;
 const FLAG = /^-{1,2}/;
 const PREFIX = /^--no-/i;
 
-function isNum(any) {
-	const num = +any;
-	if (num * 0 !== 0) return false; // undefined, NaN, Infinity, boolean
-	if (num === any) return true;
-	if (typeof any === 'string' && any.trim() !== '') return true;
-	return false; // null
-}
-
 function isBool(any) {
 	return typeof any === 'boolean';
 }
@@ -29,7 +21,8 @@ function toBool(any) {
 }
 
 function toNum(any) {
-	return isNum(any) ? Number(any) : any;
+	let x = Number(any);
+	return !isBool(any) && (x * 0 === 0) ? x : any;
 }
 
 function getAlibi(names, arr) {

--- a/test/index.js
+++ b/test/index.js
@@ -25,6 +25,8 @@ test('comprehensive', t => {
 			'--bool',
 			'--no-meep',
 			'--multi=baz',
+			'--number=-123',
+			'--zeronum=0',
 			'--',
 			'--not-a-flag',
 			'eek'
@@ -41,6 +43,8 @@ test('comprehensive', t => {
 			multi: ['quux', 'baz'],
 			meep: false,
 			name: 'meowmers',
+			number: -123,
+			zeronum: 0,
 			_: ['bare', '--not-a-flag', 'eek']
 		}
 	);


### PR DESCRIPTION
closes #3 
add `function isNum()` to check number like string value correctly.
```
// before
[--num=0] => {num: '0'}
// after
[--num=0] => {num: 0}
```