### PR TITLE
[CRITICAL] Update 2.0 for NextJS Commerce compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ function toVal(out, key, val, opts) {
 	out[key] = old == null ? nxt : (Array.isArray(old) ? old.concat(nxt) : [old, nxt]);
 }
 
-export default function (args, opts) {
+const mri = (args, opts) {
 	args = args || [];
 	opts = opts || {};
 
@@ -117,3 +117,5 @@ export default function (args, opts) {
 
 	return out;
 }
+
+module.exports = mri

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ function toVal(out, key, val, opts) {
 	out[key] = old == null ? nxt : (Array.isArray(old) ? old.concat(nxt) : [old, nxt]);
 }
 
-const mri = (args, opts) {
+const mri = (args, opts) => {
 	args = args || [];
 	opts = opts || {};
 


### PR DESCRIPTION
Added `const` to default export. Changed to a more natively recognized syntax for nodeJs by exporting the default function with a `module.exports` instead.
- No breaking changes.
- @maraisr @jimmyolo @lukeed @leo 
This is an urgent merge as this library it breaking builds for NextJS commerce users.