### PR TITLE
types: allow readonly config + better type inferring

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,15 @@
 type Dict<T> = Record<string, T>;
-type Arrayable<T> = T | T[];
+type Arrayable<T> = T | readonly T[];
 type Default = Dict<any>;
 
-declare function mri<T=Default>(args?: string[], options?: mri.Options): mri.Argv<T>;
+declare function mri<T=Default>(args?: string[], options?: mri.Options<T>): mri.Argv<T>;
 
 declare namespace mri {
-	export interface Options {
+	export interface Options<D extends Dict<any> =Default> {
 		boolean?: Arrayable<string>;
 		string?: Arrayable<string>;
 		alias?: Dict<Arrayable<string>>;
-		default?: Dict<any>;
+		default?: D;
 		unknown?(flag: string): void;
 	}
 


### PR DESCRIPTION
The readonly is there so you can build your type from const arrays [like here](https://github.com/BuilderIO/qwik/blob/c5155a284a58d5a77d03ce4ae8fb35838463ec60/scripts/util.ts#L45-L79).

The inferral is so that the shape of the default parameter can be used to determine the return type, or vice versa to ensure that the defaults match the type